### PR TITLE
First commit `load_file_par`

### DIFF
--- a/src/directory.rs
+++ b/src/directory.rs
@@ -94,6 +94,10 @@ impl <'a> DirStruct <'a> {
 }
 
 impl <'a> DirStruct <'a> {
+
+    // We have to reimplement this functions in order to load the files in parallel 
+    // using the full disk bandwidth
+
     pub fn create_observations(&self, id_mc_ref: &str, sky_t: Vec<f32>) -> Obs {
         
         let mut tod_vec: Vec<Vec<f32>> = Vec::new();


### PR DESCRIPTION
The function `load_file` is very inefficient and now it represents a bottle neck for the execution times. 
I am not sure if this issue can be mitigated, any way I have opened this PR in order to find out this problem and for implementing a different version of this function.

